### PR TITLE
Add CAD engine loading indicator on web interface

### DIFF
--- a/packages/ogt-web/src/components/JsonExport.tsx
+++ b/packages/ogt-web/src/components/JsonExport.tsx
@@ -100,6 +100,11 @@ export function JsonExport({ rows, cols, toGridPlan }: JsonExportProps) {
           filename={`${filenameBase}.stl`}
           disabled={workerState.status !== "ready"}
         />
+        {workerState.status === "loading" && (
+          <span className="text-sm text-muted-foreground">
+            Loading CAD engine…
+          </span>
+        )}
         {workerState.status === "error" && (
           <span className="text-sm text-red-600">{workerState.error}</span>
         )}


### PR DESCRIPTION
## Summary
- Show "Loading CAD engine…" text next to the disabled STEP/STL export buttons while the WASM worker is loading
- Uses the same flex row and muted text style as the existing error state indicator
- No new dependencies or components; just a conditional span in `JsonExport.tsx`

## Test plan
- [ ] Open the web app and verify "Loading CAD engine…" appears briefly while the WASM engine loads
- [ ] Verify the text disappears once the engine is ready and buttons become enabled
- [ ] Verify error state still displays correctly if the engine fails to load

🤖 Generated with [Claude Code](https://claude.com/claude-code)