### PR TITLE
Add oG favicon to web interface

### DIFF
--- a/packages/ogt-web/index.html
+++ b/packages/ogt-web/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>openGrid Generator</title>
   </head>
   <body>

--- a/packages/ogt-web/public/favicon.svg
+++ b/packages/ogt-web/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#18181b"/>
+  <text x="16" y="22" font-family="system-ui, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">oG</text>
+</svg>


### PR DESCRIPTION
## Summary
- Add an SVG favicon with "oG" text (dark background, white text, rounded rect) at `packages/ogt-web/public/favicon.svg`
- Link the favicon in `packages/ogt-web/index.html`

## Test plan
- [x] All web CI checks pass locally (lint, typecheck, format, build)
- [x] `favicon.svg` present in build output (`dist/`)
- [x] `dist/index.html` contains the favicon link

🤖 Generated with [Claude Code](https://claude.com/claude-code)