### PR TITLE
Fix CLI loading indicator not displaying before import

### DIFF
--- a/packages/ogt-py/src/ogt/cli.py
+++ b/packages/ogt-py/src/ogt/cli.py
@@ -2,6 +2,7 @@
 
 import functools
 import json
+import sys
 from pathlib import Path
 
 import click
@@ -134,6 +135,7 @@ def draw(plan_file, fmt, output):
     from pydantic import ValidationError
 
     click.echo("Loading CAD engine (may take up to 1 min on first run)…", nl=False)
+    sys.stdout.flush()
     from ogt.draw import draw_grid
     from ogt.prepare.types import GridPlan
 
@@ -162,6 +164,7 @@ def draw(plan_file, fmt, output):
 def generate(code, layout, opengrid_type, connectors, tile_chamfers, screws, output, fmt):
     """Prepare and draw in one step — from compact CODE or --size to geometry."""
     click.echo("Loading CAD engine (may take up to 1 min on first run)…", nl=False)
+    sys.stdout.flush()
     from ogt.draw import draw_grid
 
     click.echo(" done.")


### PR DESCRIPTION
## Summary
- The "Loading CAD engine" message was not visible because Python's stdout is line-buffered and `click.echo(..., nl=False)` does not flush
- Added `sys.stdout.flush()` after each loading message echo in the `draw` and `generate` CLI commands so the message appears immediately before the slow import

## Test plan
- [x] Verified with a simulation script that the message appears before the delay
- [x] All Python CI checks pass (`ruff check`, `ruff format --check`, `ty check`, `pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)